### PR TITLE
Add Github Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,50 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: '[BUG] '
+labels: bug
+assignees: ''
+---
+
+## Describe the bug
+A clear and concise description of what the bug is.
+
+## To Reproduce
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+## Expected behavior
+A clear and concise description of what you expected to happen.
+
+## Screenshots
+If applicable, add screenshots to help explain your problem.
+
+## Environment
+**BLE Plugin Bridge Version:** [e.g. 2.5.5]
+**Home Assistant Version:** [e.g. 2026.1.1]
+**Plugin Installed Location** [e.g. Android TV / Google TV]
+**MQTT Broker Name & Version:** [Mosquitto broker, 6.5.2]
+
+## Logs
+Please include relevant logs from the BLE Plugin Bridge and Home Assistant (Settings → System → Logs) if applicable.
+
+```
+Paste your logs here
+```
+
+## Configuration
+How did you configure the integration?
+- IP Address: [e.g. 192.168.1.1]
+- Update Interval: [e.g. 30 seconds]
+
+## Additional context
+Add any other context about the problem here.
+
+## Checklist
+- [ ] I have checked existing issues for duplicates
+- [ ] I have included BLE Plugin Bridge logs
+- [ ] I have included Home Assistant logs
+- [ ] I have tested with the latest version of the BLE Plugin Bridge

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,30 @@
+---
+name: Feature request
+about: Suggest an idea for this integration
+title: '[FEATURE] '
+labels: enhancement
+assignees: ''
+---
+
+## Is your feature request related to a problem?
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+## Describe the solution you'd like
+A clear and concise description of what you want to happen.
+
+## Describe alternatives you've considered
+A clear and concise description of any alternative solutions or features you've considered.
+
+## Use Case
+How would this feature benefit users? What problem does it solve?
+
+## Example Configuration/Usage
+If applicable, show how you'd like to use this feature or other similar cases where this request is used:
+
+## Additional context
+Add any other context, screenshots, or examples about the feature request here.
+
+## Checklist
+- [ ] I have checked existing issues for similar requests
+- [ ] This feature is relevant to the BLE Plugin Bridge
+- [ ] I have provided a clear use case


### PR DESCRIPTION
This PR adds Github Issue Templates for Bug Reports and Feature Requests. These templates are slightly modified versions of what Claude provided me for my HACS integration repository.